### PR TITLE
Improvements to comparisons, function matching

### DIFF
--- a/R/crossvalidation.R
+++ b/R/crossvalidation.R
@@ -12,6 +12,7 @@ cvrisk.mboost <- function (object, folds = cv(model.weights(object)),
                            fun = NULL, corrected = TRUE, mc.preschedule = FALSE,
                            ...) {
 
+    appfun <- match.fun(papply)
     weights <- model.weights(object)
     if (any(weights == 0))
         warning("zero weights")
@@ -72,15 +73,15 @@ cvrisk.mboost <- function (object, folds = cv(model.weights(object)),
     ## use case weights as out-of-bag weights (but set inbag to 0)
     OOBweights <- matrix(rep(weights, ncol(folds)), ncol = ncol(folds))
     OOBweights[folds > 0] <- 0
-    if (identical(papply, mclapply)) {
-        oobrisk <- papply(1:ncol(folds),
+    if (identical(appfun, mclapply)) {
+        oobrisk <- appfun(1:ncol(folds),
                           function(i) try(dummyfct(weights = folds[, i],
                                                    oobweights = OOBweights[, i]),
                                           silent = TRUE),
                           mc.preschedule = mc.preschedule,
                           ...)
     } else {
-        oobrisk <- papply(1:ncol(folds),
+        oobrisk <- appfun(1:ncol(folds),
                           function(i) try(dummyfct(weights = folds[, i],
                                                    oobweights = OOBweights[, i]),
                                           silent = TRUE),

--- a/R/crossvalidation.R
+++ b/R/crossvalidation.R
@@ -72,7 +72,7 @@ cvrisk.mboost <- function (object, folds = cv(model.weights(object)),
     ## use case weights as out-of-bag weights (but set inbag to 0)
     OOBweights <- matrix(rep(weights, ncol(folds)), ncol = ncol(folds))
     OOBweights[folds > 0] <- 0
-    if (all.equal(papply, mclapply) == TRUE) {
+    if (identical(papply, mclapply)) {
         oobrisk <- papply(1:ncol(folds),
                           function(i) try(dummyfct(weights = folds[, i],
                                                    oobweights = OOBweights[, i]),

--- a/R/survival.R
+++ b/R/survival.R
@@ -6,7 +6,7 @@ survFit.mboost <- function(object, newdata = NULL, ...)
 {
 
     n <- length(w <- model.weights(object))
-    if (!all.equal(w,rep(1,n)))
+    if (!isTRUE(all.equal(w,rep(1,n))))
         stop("survFit cannot (yet) deal with weights")
     y <- object$response
     stopifnot(inherits(y, "Surv"))


### PR DESCRIPTION
- More robust use of `all.equal()` on one occasion.
- It's better to use `identical()` than `all.equal()` when testing for exact match.
- Argument `papply` may now also be the name of a function.
