### PR TITLE
fix predict with 0 iters

### DIFF
--- a/R/mboost.R
+++ b/R/mboost.R
@@ -266,7 +266,7 @@ mboost_fit <- function(blg, response, weights = rep(1, NROW(response)),
         if (mstop == 0) {
             if (length(offset) == 1) {
                 if (!is.null(newdata))
-                    return(rep(offset, NCOL(newdata)))
+                    return(rep(offset, NROW(newdata)))
                 return(rep(offset, NROW(y)))
             } 
             if (!is.null(newdata)) {

--- a/tests/bugfixes.R
+++ b/tests/bugfixes.R
@@ -575,3 +575,17 @@ mboost(y ~ bols(x), data = myData, weights = weights, family = Gaussian())
 ## was always working
 glmboost(y ~ x, data = myData, weights = weights, family = Gaussian())
 blackboost(y ~ x, data = myData, weights = weights, family = Gaussian())
+
+
+# predict with mstop = 0
+set.seed(1907)
+x1 <- rnorm(100)
+x2 <- rnorm(100)
+x3 <- rnorm(100)
+y <- rnorm(100, mean = 3 * x1, sd = 2)
+DF <- data.frame(y = y, x1 = x1, x2 = x2, x3 = x3)
+predict(glmboost(y ~ ., data = DF, control = boost_control(mstop = 0)), newdata = DF)
+predict(glmboost(y ~ ., data = DF, control = boost_control(mstop = 0)))
+
+
+

--- a/tests/bugfixes.R
+++ b/tests/bugfixes.R
@@ -577,15 +577,4 @@ glmboost(y ~ x, data = myData, weights = weights, family = Gaussian())
 blackboost(y ~ x, data = myData, weights = weights, family = Gaussian())
 
 
-# predict with mstop = 0
-set.seed(1907)
-x1 <- rnorm(100)
-x2 <- rnorm(100)
-x3 <- rnorm(100)
-y <- rnorm(100, mean = 3 * x1, sd = 2)
-DF <- data.frame(y = y, x1 = x1, x2 = x2, x3 = x3)
-predict(glmboost(y ~ ., data = DF, control = boost_control(mstop = 0)), newdata = DF)
-predict(glmboost(y ~ ., data = DF, control = boost_control(mstop = 0)))
-
-
 

--- a/tests/testthat/test-bugs.R
+++ b/tests/testthat/test-bugs.R
@@ -1,0 +1,8 @@
+require("mboost")
+
+### check confidence intervals
+test_that("predict with mstop = 0 works", {
+    glm <- glmboost(speed ~ dist, data = cars, control = boost_control(mstop = 0))
+    expect_silent(p <- predict(m, type = "response", newdata = cars))
+    expect_equal(names(p), as.character(1:50))
+})


### PR DESCRIPTION
Fix #87 

Pretty simple bug :)

that seems to fix the example posted in https://github.com/boost-R/gamboostLSS/issues/48 as well.

