### PR TITLE
Search for baselearner in this package

### DIFF
--- a/R/mboost.R
+++ b/R/mboost.R
@@ -518,15 +518,11 @@ mboost <- function(formula, data = list(), na.action = na.omit, weights = NULL,
 
     if (is.character(baselearner)) {
         baselearner <- match.arg(baselearner)
-        bname <- baselearner
         if (baselearner %in% c("bss", "bns")) {
             warning("bss and bns are deprecated, bbs is used instead")
             baselearner <- "bbs"
         }
-        baselearner <- get(baselearner, mode = "function",
-                           envir = parent.frame())
-    } else {
-        bname <- deparse(substitute(baselearner))
+        baselearner <- get(baselearner, mode = "function")
     }
     stopifnot(is.function(baselearner))
 


### PR DESCRIPTION
Search for `baselearner` in this package, not in the caller's namespace.

When `baselearner` is given as a string, it's limited (by `match.arg`) to the pre-defined choices `c("bbs", "bols", "btree", "bss", "bns")`.  It doesn't make sense to require the caller to import that symbol when we know it's defined in the `mboost` package anyway.

In my case, I'm invoking `mboost` through a third-party package that does cross-validation, so it's impossible for me to import `btree` into that namespace.  The only solution is to do a shotgun `library(mboost)` to export the `btree` symbol globally, but I'd like to avoid that.

I also noticed that the `bname` variable is never used, so I got rid of it.