### PR TITLE
Fix `survFit()` for single row in `newdata`

### DIFF
--- a/R/survival.R
+++ b/R/survival.R
@@ -29,7 +29,7 @@ survFit.mboost <- function(object, newdata = NULL, ...)
     devent <- n.event > 0
     if (!is.null(newdata)){
         S <- exp( tcrossprod( -H, exp(as.numeric(predict(object,
-        newdata=newdata)- mean(predict(object)))) ))[devent,]
+        newdata=newdata)- mean(predict(object)))) ))[devent, , drop = FALSE]
         colnames(S) <- rownames(newdata)
     } else S <- matrix(exp(-H)[devent], ncol = 1)
 


### PR DESCRIPTION
closes #117 

``` r
library(mboost)
#> Loading required package: parallel
#> Loading required package: stabs
library(survival)

mod <- blackboost(Surv(time, status) ~ age + ph.ecog, 
                  data = lung, 
                  family = CoxPH())
sF_1 <- survFit(mod, lung[1,])
```

<sup>Created on 2022-05-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>