### PR TITLE
survFit: support models fitted with case weights

### DIFF
--- a/R/survival.R
+++ b/R/survival.R
@@ -5,20 +5,25 @@ survFit <- function(object, ...)
 survFit.mboost <- function(object, newdata = NULL, ...)
 {
 
-    n <- length(w <- model.weights(object))
-    if (!isTRUE(all.equal(w,rep(1,n))))
-        stop("survFit cannot (yet) deal with weights")
+    w <- model.weights(object)
     y <- object$response
     stopifnot(inherits(y, "Surv"))
+
+    pr <- predict(object)
+    ### center linear predictor around its weighted mean such that the
+    ### baseline curve corresponds to the (weighted) "average" observation
+    lpc <- weighted.mean(pr, w)
 
     ord <- order(y[,1])
     time <- y[ord,1]
     event <- y[ord,2]
-    n.event <- aggregate(event, by = list(time), sum)[,2]
+    w <- w[ord]
+    ### weighted number of events at each time point
+    n.event <- aggregate(w * event, by = list(time), sum)[,2]
 
-    pr <- predict(object)
-    linpred <- (pr - mean(pr))[ord]
-    R <- rev(cumsum(rev(exp(linpred))))
+    linpred <- (pr - lpc)[ord]
+    ### weighted Breslow estimator of the cumulative baseline hazard
+    R <- rev(cumsum(rev(w * exp(linpred))))
     R[R<1e-6] <- Inf
 
     d <- c(1,diff(time)) != 0
@@ -29,7 +34,7 @@ survFit.mboost <- function(object, newdata = NULL, ...)
     devent <- n.event > 0
     if (!is.null(newdata)){
         S <- exp( tcrossprod( -H, exp(as.numeric(predict(object,
-        newdata=newdata)- mean(predict(object)))) ))[devent,]
+        newdata=newdata) - lpc)) ))[devent, , drop = FALSE]
         colnames(S) <- rownames(newdata)
     } else S <- matrix(exp(-H)[devent], ncol = 1)
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,13 @@
 \title{News for Package 'mboost'}
 
 \section{Changes in mboost version 2.9-13 (2026-07-16)}{
+  \subsection{User-visible changes}{
+    \itemize{
+      \item \code{survFit} can now deal with models fitted with case
+      weights by using the weighted Breslow estimator
+      (\url{https://github.com/boost-R/mboost/issues/121}).
+    }
+  }
   \subsection{Other}{
     \itemize{
       \item Handle M1/ARM precision issues in \file{tests}.

--- a/man/survFit.Rd
+++ b/man/survFit.Rd
@@ -23,7 +23,7 @@
 \details{
 
   If \code{newdata = NULL}, the survivor function of the Cox proportional
-  hazards model is computed for the mean of the covariates used in the
+  hazards model is computed for a centered linear predictor from the
   \code{\link{blackboost}}, \code{\link{gamboost}}, or \code{\link{glmboost}}
   call. The Breslow estimator is used for computing the baseline survivor
   function. If \code{newdata} is a data frame, the \code{\link{predict}} method

--- a/man/survFit.Rd
+++ b/man/survFit.Rd
@@ -23,7 +23,7 @@
 \details{
 
   If \code{newdata = NULL}, the survivor function of the Cox proportional
-  hazards model is computed for a centered linear predictor from the
+  hazards model is computed for a centered linear predictor based on the
   \code{\link{blackboost}}, \code{\link{gamboost}}, or \code{\link{glmboost}}
   call. The Breslow estimator is used for computing the baseline survivor
   function. If \code{newdata} is a data frame, the \code{\link{predict}} method

--- a/man/survFit.Rd
+++ b/man/survFit.Rd
@@ -30,6 +30,13 @@
   of \code{object}, along with the Breslow estimator, is used for computing the
   predicted survivor function for each row in \code{newdata}.
 
+  If the model was fitted with case weights, the weighted Breslow
+  estimator is used for computing the baseline survivor function, i.e.,
+  each observation contributes to the number of events and to the risk
+  sets according to its weight, and the survivor function for
+  \code{newdata = NULL} is computed at the weighted mean of the linear
+  predictor.
+
 }
 \value{
  An object of class \code{survFit} containing the following components:
@@ -38,7 +45,8 @@
   \item{time}{ the time points at which the survivor functions are
                evaluated. }
   \item{n.event}{ the number of events observed at each time point given
-                  in \code{time}.}
+                  in \code{time}. For models fitted with case weights,
+                  this is the weighted number of events.}
 }
 \seealso{ \code{\link{gamboost}}, \code{\link{glmboost}} and
   \code{\link{blackboost}} for model fitting.}

--- a/tests/regtest-blackboost.R
+++ b/tests/regtest-blackboost.R
@@ -84,6 +84,15 @@ newdata <- ovarian[c(1,3,12),]
 A2 <- survFit(fit2, newdata = newdata)
 print(A2)
 
+## survFit also works for models fitted with case weights
+## see https://github.com/boost-R/mboost/issues/121
+w <- seq(0.5, 1.5, length.out = nrow(ovarian))
+fit2w <- blackboost(Surv(futime,fustat) ~ age + resid.ds + rx + ecog.ps,
+    data = ovarian, family = CoxPH(), weights = w,
+    control = boost_control(mstop = 100))
+A2w <- survFit(fit2w, newdata = newdata)
+stopifnot(all(A2w$surv >= 0), all(A2w$surv <= 1))
+
 ### predictions:
 set.seed(1907)
 x1 <- rnorm(100)

--- a/tests/regtest-blackboost.Rout.save
+++ b/tests/regtest-blackboost.Rout.save
@@ -104,6 +104,15 @@ Loading required package: stabs
 + A2 <- survFit(fit2, newdata = newdata)
 + print(A2)
 + 
++ ## survFit also works for models fitted with case weights
++ ## see https://github.com/boost-R/mboost/issues/121
++ w <- seq(0.5, 1.5, length.out = nrow(ovarian))
++ fit2w <- blackboost(Surv(futime,fustat) ~ age + resid.ds + rx + ecog.ps,
++     data = ovarian, family = CoxPH(), weights = w,
++     control = boost_control(mstop = 100))
++ A2w <- survFit(fit2w, newdata = newdata)
++ stopifnot(all(A2w$surv >= 0), all(A2w$surv <= 1))
++ 
 + ### predictions:
 + set.seed(1907)
 + x1 <- rnorm(100)

--- a/tests/regtest-glmboost.R
+++ b/tests/regtest-glmboost.R
@@ -197,6 +197,36 @@ A3 <- survFit(fit3, newdata = newdata)
 max(A1$surv-A2$surv)
 max(A1$surv-A3$surv)
 
+## survFit for models fitted with case weights
+## see https://github.com/boost-R/mboost/issues/121
+
+## integer case weights: same results as fitting on the expanded data
+w <- rep(1:2, length.out = nrow(ovarian))
+fit4 <- glmboost(fm, data = ovarian, family = CoxPH(), weights = w,
+    control = boost_control(mstop = 1000), center = FALSE)
+fit5 <- glmboost(fm, data = ovarian[rep(1:nrow(ovarian), w),], family = CoxPH(),
+    control = boost_control(mstop = 1000), center = FALSE)
+A4 <- survFit(fit4)
+A5 <- survFit(fit5)
+print(.all.equal(A4$surv, A5$surv))
+print(.all.equal(A4$time, A5$time))
+print(.all.equal(A4$n.event, A5$n.event))
+A4 <- survFit(fit4, newdata = newdata)
+A5 <- survFit(fit5, newdata = newdata)
+print(.all.equal(A4$surv, A5$surv))
+
+## non-integer case weights: compare with weighted coxph fit
+wts <- seq(0.5, 1.5, length.out = nrow(ovarian))
+fitw <- coxph(fmSurv, data = ovarian, weights = wts)
+fit6 <- glmboost(fm, data = ovarian, family = CoxPH(), weights = wts,
+    control = boost_control(mstop = 1000), center = TRUE)
+A1 <- survfit(fitw, censor = FALSE)
+A6 <- survFit(fit6)
+print(max(abs(A1$surv - A6$surv)) < 0.001)
+A1 <- survfit(fitw, newdata = newdata, censor = FALSE)
+A6 <- survFit(fit6, newdata = newdata)
+print(max(abs(A1$surv - A6$surv)) < 0.001)
+
 ### Poisson models
 
 df <- data.frame(x1 = runif(100), x2 = runif(100))

--- a/tests/regtest-glmboost.Rout.save
+++ b/tests/regtest-glmboost.Rout.save
@@ -289,6 +289,45 @@ In glmboost.formula(fm, data = ovarian, family = CoxPH(), control = boost_contro
 > max(A1$surv-A3$surv)
 [1] 0.189
 > 
+> ## survFit for models fitted with case weights
+> ## see https://github.com/boost-R/mboost/issues/121
+> 
+> ## integer case weights: same results as fitting on the expanded data
+> w <- rep(1:2, length.out = nrow(ovarian))
+> fit4 <- glmboost(fm, data = ovarian, family = CoxPH(), weights = w,
++     control = boost_control(mstop = 1000), center = FALSE)
+> fit5 <- glmboost(fm, data = ovarian[rep(1:nrow(ovarian), w),], family = CoxPH(),
++     control = boost_control(mstop = 1000), center = FALSE)
+> A4 <- survFit(fit4)
+> A5 <- survFit(fit5)
+> print(.all.equal(A4$surv, A5$surv))
+[1] TRUE
+> print(.all.equal(A4$time, A5$time))
+[1] TRUE
+> print(.all.equal(A4$n.event, A5$n.event))
+[1] TRUE
+> A4 <- survFit(fit4, newdata = newdata)
+> A5 <- survFit(fit5, newdata = newdata)
+> print(.all.equal(A4$surv, A5$surv))
+[1] TRUE
+> 
+> ## non-integer case weights: compare with weighted coxph fit
+> wts <- seq(0.5, 1.5, length.out = nrow(ovarian))
+> fitw <- coxph(fmSurv, data = ovarian, weights = wts)
+> fit6 <- glmboost(fm, data = ovarian, family = CoxPH(), weights = wts,
++     control = boost_control(mstop = 1000), center = TRUE)
+Warning message:
+In glmboost.formula(fm, data = ovarian, family = CoxPH(), weights = wts,  :
+  model with centered covariates does not contain intercept
+> A1 <- survfit(fitw, censor = FALSE)
+> A6 <- survFit(fit6)
+> print(max(abs(A1$surv - A6$surv)) < 0.001)
+[1] TRUE
+> A1 <- survfit(fitw, newdata = newdata, censor = FALSE)
+> A6 <- survFit(fit6, newdata = newdata)
+> print(max(abs(A1$surv - A6$surv)) < 0.001)
+[1] TRUE
+> 
 > ### Poisson models
 > 
 > df <- data.frame(x1 = runif(100), x2 = runif(100))


### PR DESCRIPTION
## Summary

`survFit()` previously stopped with `"survFit cannot (yet) deal with weights"`
for any model fitted with non-unit case weights, even though `blackboost()` /
`glmboost()` / `gamboost()` happily accept `weights` with `family = CoxPH()`
(see #121, motivated by the tidymodels integration of mboost).

This PR implements the **weighted Breslow estimator** in `survFit.mboost`:

- the number of events at each time point is the *weighted* event count
  `Σ wᵢ·eventᵢ`,
- the risk-set sums are weighted: `Σ_{tⱼ ≥ t} wⱼ·exp(ηⱼ)`,
- the linear predictor is centered at its **weighted** mean, so the baseline
  curve (`newdata = NULL`) corresponds to the weighted "average" observation —
  matching `survfit.coxph()`'s convention of centering at the weighted
  covariate means.

For unit weights, `weighted.mean()` reduces to `mean()` and the computation is
**identical to the previous implementation** (verified below). Two further
properties fall out of the estimator:

- mboost's internal rescaling of non-integer weights
  (`rescale_weights()`, a constant factor) cancels in the Breslow estimator,
- zero-weight observations (e.g. from `cvrisk()`-style subsampling folds)
  correctly drop out of both events and risk sets.

Also added `drop = FALSE` when subsetting the survival matrix, so a fit with a
single distinct event time no longer collapses it to a vector.

## Changes

- `R/survival.R`: weighted Breslow estimator instead of the error.
- `man/survFit.Rd`: documents the weighted behaviour, incl. that `n.event` is
  the weighted number of events for weighted fits.
- `inst/NEWS.Rd`: entry referencing #121.
- `tests/regtest-glmboost.R` + `.Rout.save`: equivalence and coxph comparison
  tests (see below).
- `tests/regtest-blackboost.R` + `.Rout.save`: smoke test of the scenario from
  #121 (`blackboost` + `CoxPH()` + non-integer weights, `survFit` on newdata).

The tests use deterministic weights on purpose: there is no `set.seed()`
between the survFit section and the subsequent sections in the test files, so
consuming RNG draws there would silently change all downstream expected
output in the `.Rout.save` files.

## Verification (R 4.3.3, survival 3.5-8)

**Issue example now works.** The exact reprex from #121 (`blackboost` on
`lung` with `runif` weights, `survFit` on newdata) runs and returns valid,
monotone survival curves.

**Backward compatibility.** Re-running `regtest-glmboost.R` and
`regtest-gamboost.R` against the stored `.Rout.save` files with `R CMD Rdiff`
shows **zero** differences outside the newly added section — e.g. the existing
unweighted comparison still prints `max(A1$surv-A2$surv)` = `4.99e-05`
exactly as before.

**Integer case weights ≡ expanded data (exact).** Fitting `glmboost(...,
family = CoxPH(), weights = w)` with integer `w` and fitting on the
row-expanded data `ovarian[rep(1:n, w), ]` give `all.equal()`-identical
`survFit` results for `surv`, `time`, `n.event`, and newdata predictions.

**glmboost vs. weighted coxph (non-integer weights).** With
`wts <- seq(0.5, 1.5, length.out = nrow(ovarian))`:

```r
fitw <- coxph(Surv(futime, fustat) ~ age + resid.ds + rx + ecog.ps,
              data = ovarian, weights = wts)
fit6 <- glmboost(Surv(futime, fustat) ~ age + resid.ds + rx + ecog.ps - 1,
                 data = ovarian, family = CoxPH(), weights = wts,
                 control = boost_control(mstop = 1000), center = TRUE)

max(abs(survfit(fitw, censor = FALSE)$surv - survFit(fit6)$surv))
#> 6.805215e-05

newdata <- ovarian[c(1, 3, 12), ]
max(abs(survfit(fitw, newdata = newdata, censor = FALSE)$surv -
        survFit(fit6, newdata = newdata)$surv))
#> 0.0002357012
```

Both are within boosting-convergence tolerance of the partial-likelihood MLE
(the same order of magnitude as the existing unweighted comparisons in the
test file, `4.99e-05` / `8.24e-05`), and the agreement of the *baseline*
curve confirms the weighted-mean centering matches `survfit.coxph`. The
regression tests assert both differences `< 0.001`.

**Package checks.** `R CMD INSTALL` builds cleanly and
`tools::checkRd("man/survFit.Rd")` passes.

Closes #121

https://claude.ai/code/session_01HqB9XX7JjdQJ1vah4eyWv9